### PR TITLE
feat: add issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATES/bug.yaml
+++ b/.github/ISSUE_TEMPLATES/bug.yaml
@@ -1,0 +1,56 @@
+name: Bug report
+description: File a bug report
+title: "bug: "
+labels: ["bug"]
+body:
+    - type: input
+      id: area
+      attributes:
+        label: Area
+        description: |
+            What part of the project does this apply to? Can be skipped outside
+            of the monorepo.
+        placeholder: Server, client, shared, lokui, etc.
+    - type: textarea
+      id: description
+      attributes:
+          label: Description
+          description: A clear and concise explanation of what happened.
+          placeholder: Sometimes this happens and it's not supposed to...
+      validations:
+          required: true
+    - type: textarea
+      id: reproduction
+      attributes:
+          label: Minimal reproduction
+          description: |
+              The bare minimum needed to trigger the problem. May be a code
+              sample or a step-by-step guide depending on the context.
+          placeholder: |
+              1. First, do this.
+              2. Then do this.
+              3. Finally, do this.
+      validations:
+          required: true
+    - type: textarea
+      id: expected-behavior
+      attributes:
+          label: Expected behavior
+          description: What did you expect to happen?
+          placeholder: I would actually expect this to happen...
+      validations:
+          required: true
+    - type: textarea
+      id: additional-info
+      attributes:
+          label: Additional information
+          description: Additional information that may be useful.
+    - type: checkboxes
+      id: checks
+      attributes:
+          label: Checks
+          options:
+              - label: |
+                    I have checked for existing issues about this, and did not
+                    find any.
+                required: true

--- a/.github/ISSUE_TEMPLATES/bug.yaml
+++ b/.github/ISSUE_TEMPLATES/bug.yaml
@@ -7,9 +7,7 @@ body:
       id: area
       attributes:
         label: Area
-        description: |
-            What part of the project does this apply to? Can be skipped outside
-            of the monorepo.
+        description: What part of the project does this apply to? Can be skipped outside of the monorepo.
         placeholder: Server, client, shared, lokui, etc.
     - type: textarea
       id: description
@@ -23,9 +21,7 @@ body:
       id: reproduction
       attributes:
           label: Minimal reproduction
-          description: |
-              The bare minimum needed to trigger the problem. May be a code
-              sample or a step-by-step guide depending on the context.
+          description: The bare minimum needed to trigger the problem. May be a code sample or a step-by-step guide depending on the context.
           placeholder: |
               1. First, do this.
               2. Then do this.

--- a/.github/ISSUE_TEMPLATES/feature.yaml
+++ b/.github/ISSUE_TEMPLATES/feature.yaml
@@ -13,7 +13,7 @@ body:
       id: problem
       attributes:
           label: Problem
-          description: A clear and concise explanation the current problem.
+          description: A clear and concise explanation of the current problem.
           placeholder: As an X, I want to Y so that Z.
       validations:
           required: true

--- a/.github/ISSUE_TEMPLATES/feature.yaml
+++ b/.github/ISSUE_TEMPLATES/feature.yaml
@@ -1,0 +1,49 @@
+name: Feature
+description: Discuss the addition of a feature
+title: "feat: "
+labels: ["feature"]
+body:
+    - type: input
+      id: area
+      attributes:
+        label: Area
+        description: |
+            What part of the project does this apply to? Can be skipped outside
+            of the monorepo.
+        placeholder: Server, client, shared, lokui, etc.
+    - type: textarea
+      id: problem
+      attributes:
+          label: Problem
+          description: A clear and concise explanation the current problem.
+          placeholder: As an X, I want to Y so that Z.
+      validations:
+          required: true
+    - type: textarea
+      id: solution
+      attributes:
+          label: Suggested solution
+          description: What you think could be done to solve the problem.
+          placeholder: I think we could do this...
+      validations:
+          required: true
+    - type: textarea
+      id: alternatives
+      attributes:
+          label: Alternatives
+          description: What other solutions have you considered?
+          placeholder: We could also do this, but here's why I don't prefer it.
+    - type: textarea
+      id: additional-info
+      attributes:
+          label: Additional information
+          description: Additional information that may be useful.
+    - type: checkboxes
+      id: checks
+      attributes:
+          label: Checks
+          options:
+              - label: |
+                    I have checked for existing issues about this, and did not
+                    find any.
+                required: true

--- a/.github/ISSUE_TEMPLATES/feature.yaml
+++ b/.github/ISSUE_TEMPLATES/feature.yaml
@@ -7,9 +7,7 @@ body:
       id: area
       attributes:
         label: Area
-        description: |
-            What part of the project does this apply to? Can be skipped outside
-            of the monorepo.
+        description: What part of the project does this apply to? Can be skipped outside of the monorepo.
         placeholder: Server, client, shared, lokui, etc.
     - type: textarea
       id: problem

--- a/.github/ISSUE_TEMPLATES/minor.yaml
+++ b/.github/ISSUE_TEMPLATES/minor.yaml
@@ -2,7 +2,6 @@ name: Minor issue
 description: |
     Stuff like typos and other grammar. Feel free to just go ahead and fix this,
     no issue needed.
-title: ""
 labels: ["feature"]
 body:
     - type: markdown

--- a/.github/ISSUE_TEMPLATES/minor.yaml
+++ b/.github/ISSUE_TEMPLATES/minor.yaml
@@ -1,0 +1,28 @@
+name: Minor issue
+description: |
+    Stuff like typos and other grammar. Feel free to just go ahead and fix this,
+    no issue needed.
+title: ""
+labels: ["feature"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              # Hey!
+
+              You probably don't need to create an issue for this. It's faster
+              and easier to just go ahead and fix it!
+    - type: textarea
+      id: additional-info
+      attributes:
+          label: Additional information
+          description: Additional information that may be useful.
+    - type: checkboxes
+      id: checks
+      attributes:
+          label: Checks
+          options:
+              - label: |
+                    I have checked for existing issues about this, and did not
+                    find any.
+                required: true


### PR DESCRIPTION
This pull request introduces issue forms, which are useful because they provide a consistent format for issues, and makes clear what they are expected to contain. GitHub will still present an option to create a free-form issue, so it does not inhibit flexibility.

The issue forms can be previewed [here](https://github.com/loki-chat/.github/tree/issue-templates/.github/ISSUE_TEMPLATES).

The minor template is not intended to be used for actual issues, because the things it's for generally don't need them.

Feel free to provide feedback before this pull request is merged.
